### PR TITLE
select() again in wait_event() if interrupted by sigwinch

### DIFF
--- a/termbox.h
+++ b/termbox.h
@@ -2218,7 +2218,11 @@ static int wait_event(struct tb_event *event, struct timeval *timeout) {
         int select_rv = select(maxfd + 1, &rfds, NULL, NULL, timeout);
 
         if (select_rv < 0) {
-            // Let EINTR/EAGAIN bubble up
+            if (errno == EINTR) {
+                continue;
+            }
+
+            // Let EAGAIN bubble up
             global.last_errno = errno;
             return TB_ERR_SELECT;
         } else if (select_rv == 0) {


### PR DESCRIPTION
The current behaviour breaks code that polls for events like this (Such as demo/keyboard.c):

```
while (tb_poll_event(&ev) == TB_OK) {
        switch (ev.type) {
        ...
        }
}
```

select() is interrupted by the SIGWINCH handler and returns EINTR, which causes termbox to return the error value TB_ERR_SELECT. This change will make it retry select()-ing again if it was interrupted, allowing the above code to work properly.

A workaround is to poll as follows:

```
for (;;) {
    switch ((tb_poll_event(&event))) {
    case TB_OK:
        break;
    case TB_ERR_SELECT:
        continue;
    default:
        return;
    }

   switch (event.type) {
      ...
   }
```

