### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: Left
+AlignConsecutiveMacros: Consecutive
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: true
+BasedOnStyle: LLVM
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+ColumnLimit: 80
+IncludeBlocks: Regroup
+IndentWidth: 4
+PointerAlignment: Right
+SpaceAfterCStyleCast: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeParens: ControlStatements
+TabWidth: 4
+UseTab: Never
+...

--- a/termbox.h
+++ b/termbox.h
@@ -23,25 +23,25 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#ifndef __TERMBOX_H
-#define __TERMBOX_H
+#ifndef TERMBOX_H
+#define TERMBOX_H
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
-#include <stdint.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <termios.h>
 #include <unistd.h>
-#include <signal.h>
 #include <wchar.h>
-#include <limits.h>
 
 #ifdef __cplusplus
 extern "C" { // __ffi_strip
@@ -94,7 +94,7 @@ extern "C" { // __ffi_strip
 #define TB_KEY_BACKSPACE2       0x7f
 #define TB_KEY_CTRL_8           0x7f /* clash with 'BACKSPACE2'     */
 
-#define tb_key_i(i) 0xffff - (i)
+#define tb_key_i(i) (0xffff - (i))
 /* Terminal-dependent key constants (tb_event.key) and terminfo capabilities */
 /* BEGIN codegen h */
 /* Produced by ./codegen.sh on Sun, 19 Sep 2021 01:02:02 +0000 */
@@ -214,28 +214,28 @@ extern "C" { // __ffi_strip
 
 /* Common function return values unless otherwise noted */
 #define TB_OK                    0
-#define TB_ERR                  -1
-#define TB_ERR_NEED_MORE        -2
-#define TB_ERR_INIT_ALREADY     -3
-#define TB_ERR_INIT_OPEN        -4
-#define TB_ERR_MEM              -5
-#define TB_ERR_NO_EVENT         -6
-#define TB_ERR_NO_TERM          -7
-#define TB_ERR_NOT_INIT         -8
-#define TB_ERR_OUT_OF_BOUNDS    -9
-#define TB_ERR_READ             -10
-#define TB_ERR_RESIZE_IOCTL     -11
-#define TB_ERR_RESIZE_PIPE      -12
-#define TB_ERR_RESIZE_SIGACTION -13
-#define TB_ERR_SELECT           -14
-#define TB_ERR_TCGETATTR        -15
-#define TB_ERR_TCSETATTR        -16
-#define TB_ERR_UNSUPPORTED_TERM -17
-#define TB_ERR_RESIZE_WRITE     -18
-#define TB_ERR_RESIZE_SELECT    -19
-#define TB_ERR_RESIZE_READ      -20
-#define TB_ERR_RESIZE_SSCANF    -21
-#define TB_ERR_CAP_COLLISION    -22
+#define TB_ERR                  (-1)
+#define TB_ERR_NEED_MORE        (-2)
+#define TB_ERR_INIT_ALREADY     (-3)
+#define TB_ERR_INIT_OPEN        (-4)
+#define TB_ERR_MEM              (-5)
+#define TB_ERR_NO_EVENT         (-6)
+#define TB_ERR_NO_TERM          (-7)
+#define TB_ERR_NOT_INIT         (-8)
+#define TB_ERR_OUT_OF_BOUNDS    (-9)
+#define TB_ERR_READ             (-10)
+#define TB_ERR_RESIZE_IOCTL     (-11)
+#define TB_ERR_RESIZE_PIPE      (-12)
+#define TB_ERR_RESIZE_SIGACTION (-13)
+#define TB_ERR_SELECT           (-14)
+#define TB_ERR_TCGETATTR        (-15)
+#define TB_ERR_TCSETATTR        (-16)
+#define TB_ERR_UNSUPPORTED_TERM (-17)
+#define TB_ERR_RESIZE_WRITE     (-18)
+#define TB_ERR_RESIZE_SELECT    (-19)
+#define TB_ERR_RESIZE_READ      (-20)
+#define TB_ERR_RESIZE_SSCANF    (-21)
+#define TB_ERR_CAP_COLLISION    (-22)
 
 /* Function types to be used with tb_set_func() */
 #define TB_FUNC_EXTRACT_PRE     0
@@ -472,7 +472,7 @@ struct tb_cell * tb_cell_buffer();
 } // __ffi_strip
 #endif
 
-#endif /* __TERMBOX_H */
+#endif /* TERMBOX_H */
 
 #ifdef TB_IMPL
 

--- a/termbox.h
+++ b/termbox.h
@@ -1787,7 +1787,7 @@ static int init_cap_trie() {
 static int cap_trie_add(const char *cap, uint16_t key, uint8_t mod) {
     struct cap_trie_t *next, *node = &global.cap_trie;
     size_t i, j;
-    for (i = 0; i < strlen(cap); i++) {
+    for (i = 0; cap[i] != '\0'; i++) {
         char c = cap[i];
         next = NULL;
 
@@ -1830,7 +1830,7 @@ static int cap_trie_find(const char *buf, struct cap_trie_t **last, size_t *dept
     size_t i, j;
     *last = node;
     *depth = 0;
-    for (i = 0; i < strlen(buf); i++) {
+    for (i = 0; buf[i] != '\0'; i++) {
         char c = buf[i];
         next = NULL;
 


### PR DESCRIPTION
Also adds parenthesis around macros, and changes the header guard to not be a reserved name as suggested by clang-tidy. Haven't run `clang-format -i termbox.h` here to avoid creating a huge diff. The `.clang-format` file should be pretty close to the original style, let me know if I should change anything.