### PR TITLE
allow polling extra FDs along with events

### DIFF
--- a/termbox.h
+++ b/termbox.h
@@ -277,10 +277,6 @@ typedef uint32_t uintattr_t;
 typedef uint16_t uintattr_t; // __ffi_strip
 #endif
 
-#define TB_FD_READ   0
-#define TB_FD_RESIZE 1
-#define TB_FD_MAX    2
-
 /* The terminal screen is represented as 2d array of cells. The structure is
  * optimized for dealing with single-width (wcwidth()==1) Unicode code points,
  * however some support for grapheme clusters (e.g., combining diacritical

--- a/termbox.h
+++ b/termbox.h
@@ -234,11 +234,12 @@ extern "C" { // __ffi_strip
 #define TB_ERR_TCSETATTR        -16
 #define TB_ERR_UNSUPPORTED_TERM -17
 #define TB_ERR_RESIZE_WRITE     -18
-#define TB_ERR_RESIZE_SELECT    -19
+#define TB_ERR_RESIZE_POLL      -19
 #define TB_ERR_RESIZE_READ      -20
 #define TB_ERR_RESIZE_SSCANF    -21
 #define TB_ERR_CAP_COLLISION    -22
 #define TB_ERR_SELECT           TB_ERR_POLL
+#define TB_ERR_RESIZE_SELECT    TB_ERR_RESIZE_POLL
 
 /* Function types to be used with tb_set_func() */
 #define TB_FUNC_EXTRACT_PRE     0
@@ -1996,7 +1997,7 @@ static int update_term_size_via_esc() {
 
     int poll_rv = poll(&fd, 1, TB_RESIZE_FALLBACK_MS);
     if (poll_rv != 1) {
-        return TB_ERR_RESIZE_SELECT;
+        return TB_ERR_RESIZE_POLL;
     }
 
     char buf[64];

--- a/termbox.h
+++ b/termbox.h
@@ -1545,7 +1545,6 @@ int tb_event_from_fds(struct tb_event *event, struct pollfd fds[TB_FD_MAX]) {
     char buf[64];
 
     memset(event, 0, sizeof(*event));
-    if_ok_return(rv, extract_event(event));
 
     if (fds[TB_FD_READ].revents & POLLIN) {
         ssize_t read_rv = read(global.rfd, buf, sizeof(buf));
@@ -1554,6 +1553,7 @@ int tb_event_from_fds(struct tb_event *event, struct pollfd fds[TB_FD_MAX]) {
             return TB_ERR_READ;
         } else if (read_rv > 0) {
             bytebuf_nputs(&global.in, buf, read_rv);
+            if_ok_return(rv, extract_event(event));
         }
     }
 
@@ -2302,6 +2302,9 @@ static int wait_event(struct tb_event *event, int timeout) {
         if (rv != TB_ERR_NO_EVENT) {
             break;
         }
+
+        fds[TB_FD_READ].revents = 0;
+        fds[TB_FD_RESIZE].revents = 0;
     } while (timeout == -1);
 
     return rv;

--- a/termbox.h
+++ b/termbox.h
@@ -192,7 +192,6 @@ extern "C" { // __ffi_strip
 #define TB_EVENT_KEY    1
 #define TB_EVENT_RESIZE 2
 #define TB_EVENT_MOUSE  3
-#define TB_EVENT_FD     4
 
 /* Key modifiers (bitwise) (tb_event.mod) */
 #define TB_MOD_ALT      1
@@ -322,8 +321,6 @@ struct tb_cell {
  *    when TB_EVENT_RESIZE: w, h
  *
  *    when TB_EVENT_MOUSE: key (TB_KEY_MOUSE_*), x, y
- *
- *    when TB_EVENT_FD: None, check the passed FDs instead.
  */
 struct tb_event {
     uint8_t type; /* one of TB_EVENT_* constants */

--- a/termbox.h
+++ b/termbox.h
@@ -2302,9 +2302,6 @@ static int wait_event(struct tb_event *event, int timeout) {
         if (rv != TB_ERR_NO_EVENT) {
             break;
         }
-
-        fds[TB_FD_READ].revents = 0;
-        fds[TB_FD_RESIZE].revents = 0;
     } while (timeout == -1);
 
     return rv;


### PR DESCRIPTION
Hi, this PR allows passing in extra FDs that termbox will poll on, in addition to the internal FDs. The API is similar to libcurl's [curl_multi_poll](https://curl.se/libcurl/c/curl_multi_poll.html) function. Hopefully this is within scope of termbox.

In my case, I am writing a client where the main thread handles the UI and 2nd thread handles data from server. So I'm going to use a self-pipe (like termbox does for resizing), which the 2nd thread will write to, on receiving new data and this would allow me to trigger a redraw on the main thread.

Also swaps out `select` for `poll` since it's safer and the API is cleaner to work with.

But there are a couple of issues, which I've highlighted in the "reviews" below.