### PR TITLE
save errno in resize handler, deinit signal handler in tb_shutdown()

### DIFF
--- a/termbox.h
+++ b/termbox.h
@@ -2111,6 +2111,8 @@ static int tb_deinit() {
             global.ttyfd_open = 0;
         }
     }
+
+    sigaction(SIGWINCH, &(struct sigaction){.sa_handler = SIG_DFL}, NULL);
     if (global.resize_pipefd[0] >= 0)
         close(global.resize_pipefd[0]);
     if (global.resize_pipefd[1] >= 0)
@@ -2728,7 +2730,9 @@ static int resize_if_needed() {
 }
 
 static void handle_resize(int sig) {
+    int errno_copy = errno;
     write(global.resize_pipefd[1], &sig, sizeof(sig));
+    errno = errno_copy;
 }
 
 static int send_attr(uintattr_t fg, uintattr_t bg) {


### PR DESCRIPTION
Spotted these issues with a bug in my program.

```
WARNING: ThreadSanitizer: signal handler spoils errno (pid=32545)
    #0 handle_resize /.../third_party/termbox2/termbox.h:2728
    #1 cleanup /.../src/main.c:30:3
    #2 main /.../src/main.c
    #3 __libc_start_call_main libc-start.c (libc.so.6+0x299f6)
    #4 __libc_start_call_main libc-start.c (libc.so.6+0x299f6)
```

The `cleanup()` function was `pthread_join`-ing a thread that was deadlocked, after calling `tb_shutdown()` The resize handler was called during the deadlocked `pthread_join`, and termbox's resize fd's were `close()`'d, so `errno` was set by `write()` as fd's were invalid.