### PR TITLE
Run tests for non-truecolor and non-egc builds (#27)

### DIFF
--- a/.github/workflows/termbox_test.yml
+++ b/.github/workflows/termbox_test.yml
@@ -5,4 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: make test
+      - run:                             make clean test
+      - run: CFLAGS='-UTB_OPT_TRUECOLOR' make clean test # non-truecolor
+      - run: CFLAGS='-UTB_OPT_EGC'       make clean test # non-egc

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ termbox_so:=libtermbox.so
 termbox_a:=libtermbox.a
 termbox_o:=termbox.o
 termbox_h:=termbox.h
+termbox_ffi_h:=termbox.ffi.h
 
 all: $(termbox_demos)
 
@@ -21,14 +22,17 @@ $(termbox_so): $(termbox_o)
 $(termbox_a): $(termbox_o)
 	$(AR) rcs $@ $(termbox_o)
 
+$(termbox_ffi_h): $(termbox_h)
+	awk '/__ffi_start/{p=1} p==1 || /__TERMBOX_H/{print}' $^ | $(CC) -DTB_OPT_TRUECOLOR -DTB_OPT_EGC $(termbox_cflags) -P -E - >$@
+
 terminfo:
 	awk -vg=0 'g==0{print} /BEGIN codegen h/{g=1; system("./codegen.sh h")} /END codegen h/{g=0; print} g==1{next}' termbox.h >termbox.h.tmp && mv -vf termbox.h.tmp termbox.h
 	awk -vg=0 'g==0{print} /BEGIN codegen c/{g=1; system("./codegen.sh c")} /END codegen c/{g=0; print} g==1{next}' termbox.h >termbox.h.tmp && mv -vf termbox.h.tmp termbox.h
 
-test: $(termbox_so)
-	docker build -f tests/Dockerfile .
+test: $(termbox_so) $(termbox_ffi_h)
+	docker build -f tests/Dockerfile --build-arg=cflags="$(termbox_cflags)" .
 
-test_local: $(termbox_so)
+test_local: $(termbox_so) $(termbox_ffi_h)
 	./tests/run.sh
 
 install:
@@ -36,6 +40,6 @@ install:
 	install -p -m 644 $(termbox_h) $(DESTDIR)$(prefix)/include/$(termbox_h)
 
 clean:
-	rm -f $(termbox_demos) $(termbox_o) $(termbox_a) $(termbox_so) tests/**/observed.ansi
+	rm -f $(termbox_demos) $(termbox_o) $(termbox_a) $(termbox_so) $(termbox_ffi_h) tests/**/observed.ansi
 
 .PHONY: all terminfo test test_local install clean

--- a/termbox.h
+++ b/termbox.h
@@ -57,7 +57,7 @@ SOFTWARE.
 #include <wchar.h>
 
 #ifdef __cplusplus
-extern "C" { // __ffi_strip
+extern "C" {
 #endif
 
 /* ASCII key constants (tb_event.key) */
@@ -297,10 +297,12 @@ extern "C" { // __ffi_strip
 #define tb_free    free
 #endif
 
+// __ffi_start
+
 #ifdef TB_OPT_TRUECOLOR
 typedef uint32_t uintattr_t;
 #else
-typedef uint16_t uintattr_t; // __ffi_strip
+typedef uint16_t uintattr_t;
 #endif
 
 /* The terminal screen is represented as 2d array of cells. The structure is
@@ -517,11 +519,12 @@ int tb_utf8_char_to_unicode(uint32_t *out, const char *c);
 int tb_utf8_unicode_to_char(char *out, uint32_t c);
 int tb_last_errno();
 const char *tb_strerror(int err);
-
 struct tb_cell *tb_cell_buffer();
+int tb_has_truecolor();
+int tb_has_egc();
 
 #ifdef __cplusplus
-} // __ffi_strip
+}
 #endif
 
 #endif /* __TERMBOX_H */
@@ -1824,6 +1827,22 @@ const char *tb_strerror(int err) {
         default:
             return strerror(global.last_errno);
     }
+}
+
+int tb_has_truecolor() {
+#ifdef TB_OPT_TRUECOLOR
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+int tb_has_egc() {
+#ifdef TB_OPT_EGC
+    return 1;
+#else
+    return 0;
+#endif
 }
 
 static int tb_reset() {

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,14 +1,16 @@
-FROM debian:10-slim
-RUN apt update \
- && apt install -y lsb-release apt-transport-https ca-certificates wget \
- && wget -O /etc/apt/trusted.gpg.d/php.gpg 'https://packages.sury.org/php/apt.gpg' \
+FROM debian:11-slim
+ARG cflags=""
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get -y update >/dev/null \
+ && apt-get -y install lsb-release apt-transport-https ca-certificates wget >/dev/null \
+ && wget -qO /etc/apt/trusted.gpg.d/php.gpg 'https://packages.sury.org/php/apt.gpg' \
  && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | \
     tee /etc/apt/sources.list.d/php.list \
- && apt update \
- && apt install -y make gcc php7.4 php7.4-mbstring xvfb xterm xvkbd locales locales-all
+ && apt-get -y update >/dev/null \
+ && apt-get -y install make gcc php8.0-cli xvfb xterm xvkbd locales locales-all >/dev/null
 ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8
 COPY . /termbox
 WORKDIR /termbox
-RUN make clean test_local
+RUN CFLAGS="${cflags}" make clean test_local

--- a/tests/test_color_true/test.php
+++ b/tests/test_color_true/test.php
@@ -1,6 +1,11 @@
 <?php
 declare(strict_types=1);
 
+if (!$test->ffi->tb_has_truecolor()) {
+    // This will only work with truecolor support
+    $test->skip();
+}
+
 $css_colors = [
     'aliceblue'            => 0xf0f8ff,
     'antiquewhite'         => 0xfaebd7,

--- a/tests/test_non_spacing_mark/test.php
+++ b/tests/test_non_spacing_mark/test.php
@@ -1,6 +1,11 @@
 <?php
 declare(strict_types=1);
 
+if (!$test->ffi->tb_has_egc()) {
+    // This will only work with extended grapheme cluster support
+    $test->skip();
+}
+
 $test->ffi->tb_init();
 
 $test->ffi->tb_print(0, 0, 0, 0, "STARG\xce\x9b\xcc\x8aTE SG-1");


### PR DESCRIPTION
This patch introduces a few new things:

* Build artifact termbox.ffi.h for easier FFI header file parsing. As a result, no more `__ffi_strip` bs, but probably more complex overall. The other idea I had would have been uglier. I think the test coverage is worth it.

* Functions `tb_has_truecolor` and `tb_has_egc` for determining support for those features at runtime.

* Test container uses `debian:11-slim` image instead of `debian:10-slim`.

* Test container uses PHP 8 instead of PHP 7.

* Test container now accepts `cflags` build argument.

* Tests can now be skipped via `$test->skip()`.

* Test suite covers 3 different builds: normal, non-truecolor, non-egc.