### PR TITLE
add soname and install rules (#39)

### DIFF
--- a/.github/workflows/termbox_test.yml
+++ b/.github/workflows/termbox_test.yml
@@ -5,6 +5,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run:                             make clean test
-      - run: CFLAGS='-UTB_OPT_TRUECOLOR' make clean test # non-truecolor
-      - run: CFLAGS='-UTB_OPT_EGC'       make clean test # non-egc
+      - run:                        make clean test
+      - run: CFLAGS='-UTB_LIB_OPTS' make clean test # non-egc, non-truecolor

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ termbox.o
 libtermbox.a
 libtermbox.so*
 termbox.ffi.h
+termbox.h.lib
 demo/keyboard

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 termbox.o
 libtermbox.a
-libtermbox.so
+libtermbox.so*
 termbox.ffi.h
 demo/keyboard

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,25 @@ prefix?=/usr/local
 
 termbox_cflags:=-std=c99 -Wall -Wextra -pedantic -Wno-unused-result -g -O0 -D_XOPEN_SOURCE -D_DEFAULT_SOURCE $(CFLAGS)
 termbox_demos:=$(patsubst demo/%.c,demo/%,$(wildcard demo/*.c))
-termbox_so:=libtermbox.so
-termbox_a:=libtermbox.a
-termbox_o:=termbox.o
 termbox_h:=termbox.h
 termbox_ffi_h:=termbox.ffi.h
+termbox_o:=termbox.o
+termbox_so_version_abi:=2
+termbox_so_version_minor_patch:=0.0
+termbox_so:=libtermbox.so
+termbox_so_x:=$(termbox_so).$(termbox_so_version_abi)
+termbox_so_x_y_z:=$(termbox_so_x).$(termbox_so_version_minor_patch)
+termbox_ld_soname:=soname
+termbox_a:=libtermbox.a
 
-all: $(termbox_demos)
+ifeq ($(shell $(CC) -dumpmachine | grep -q apple && echo 1), 1)
+    termbox_so:=libtermbox.dylib
+    termbox_so_x:=libtermbox.$(termbox_so_version_abi).dylib
+    termbox_so_x_y_z:=libtermbox.$(termbox_so_version_abi).$(termbox_so_version_minor_patch).dylib
+    termbox_ld_soname:=install_name
+endif
+
+all: $(termbox_demos) $(termbox_so) $(termbox_a)
 
 $(termbox_demos): %: %.c
 	$(CC) -DTB_OPT_TRUECOLOR -DTB_OPT_EGC $(termbox_cflags) $^ -o $@
@@ -16,8 +28,11 @@ $(termbox_demos): %: %.c
 $(termbox_o): $(termbox_h)
 	$(CC) -DTB_IMPL -DTB_OPT_TRUECOLOR -DTB_OPT_EGC -fPIC -xc -c $(termbox_cflags) $(termbox_h) -o $@
 
-$(termbox_so): $(termbox_o)
-	$(CC) -shared $(termbox_o) -o $@
+$(termbox_so_x_y_z): $(termbox_o)
+	$(CC) -shared -Wl,-$(termbox_ld_soname),$(termbox_so_x) $(termbox_o) -o $@
+
+$(termbox_so): $(termbox_so_x_y_z)
+	ln -sf $(termbox_so_x_y_z) $@
 
 $(termbox_a): $(termbox_o)
 	$(AR) rcs $@ $(termbox_o)
@@ -36,10 +51,23 @@ test_local: $(termbox_so) $(termbox_ffi_h)
 	./tests/run.sh
 
 install:
+	$(MAKE) install_h
+
+install_h: $(termbox_h)
 	install -d $(DESTDIR)$(prefix)/include
 	install -p -m 644 $(termbox_h) $(DESTDIR)$(prefix)/include/$(termbox_h)
 
-clean:
-	rm -f $(termbox_demos) $(termbox_o) $(termbox_a) $(termbox_so) $(termbox_ffi_h) tests/**/observed.ansi
+install_a: $(termbox_a)
+	install -d $(DESTDIR)$(prefix)/lib
+	install -p -m 644 $(termbox_a) $(DESTDIR)$(prefix)/lib/$(termbox_a)
 
-.PHONY: all terminfo test test_local install clean
+install_so: $(termbox_so_x_y_z)
+	install -d $(DESTDIR)$(prefix)/lib
+	install -p -m 755 $(termbox_so_x_y_z) $(DESTDIR)$(prefix)/lib/$(termbox_so_x_y_z)
+	ln -sf $(termbox_so_x_y_z) $(DESTDIR)$(prefix)/lib/$(termbox_so_x)
+	ln -sf $(termbox_so_x_y_z) $(DESTDIR)$(prefix)/lib/$(termbox_so)
+
+clean:
+	rm -f $(termbox_demos) $(termbox_o) $(termbox_a) $(termbox_so) $(termbox_so_x_y_z) $(termbox_ffi_h) tests/**/observed.ansi
+
+.PHONY: all terminfo test test_local install install_h install_a install_so clean

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ prefix?=/usr/local
 termbox_cflags:=-std=c99 -Wall -Wextra -pedantic -Wno-unused-result -g -O0 -D_XOPEN_SOURCE -D_DEFAULT_SOURCE $(CFLAGS)
 termbox_demos:=$(patsubst demo/%.c,demo/%,$(wildcard demo/*.c))
 termbox_h:=termbox.h
+termbox_h_lib:=termbox.h.lib
 termbox_ffi_h:=termbox.ffi.h
 termbox_o:=termbox.o
 termbox_so_version_abi:=2
@@ -23,13 +24,16 @@ endif
 all: $(termbox_demos) $(termbox_so) $(termbox_a)
 
 $(termbox_demos): %: %.c
-	$(CC) -DTB_OPT_TRUECOLOR -DTB_OPT_EGC $(termbox_cflags) $^ -o $@
+	$(CC) -DTB_IMPL -DTB_LIB_OPTS $(termbox_cflags) $^ -o $@
 
 $(termbox_o): $(termbox_h)
-	$(CC) -DTB_IMPL -DTB_OPT_TRUECOLOR -DTB_OPT_EGC -fPIC -xc -c $(termbox_cflags) $(termbox_h) -o $@
+	$(CC) -DTB_IMPL -DTB_LIB_OPTS -fPIC -xc -c $(termbox_cflags) $(termbox_h) -o $@
 
 $(termbox_so_x_y_z): $(termbox_o)
 	$(CC) -shared -Wl,-$(termbox_ld_soname),$(termbox_so_x) $(termbox_o) -o $@
+
+$(termbox_so_x): $(termbox_so_x_y_z)
+	ln -sf $(termbox_so_x_y_z) $@
 
 $(termbox_so): $(termbox_so_x_y_z)
 	ln -sf $(termbox_so_x_y_z) $@
@@ -38,7 +42,10 @@ $(termbox_a): $(termbox_o)
 	$(AR) rcs $@ $(termbox_o)
 
 $(termbox_ffi_h): $(termbox_h)
-	awk '/__ffi_start/{p=1} p==1 || /__TERMBOX_H/{print}' $^ | $(CC) -DTB_OPT_TRUECOLOR -DTB_OPT_EGC $(termbox_cflags) -P -E - >$@
+	awk '/__ffi_start/{p=1} p==1 || /__TERMBOX_H/{print}' $^ | $(CC) -DTB_LIB_OPTS $(termbox_cflags) -P -E - >$@
+
+$(termbox_h_lib): $(termbox_h)
+	sed 's|0 // __tb_lib_opts|1 // __tb_lib_opts|' $(termbox_h) >$@
 
 terminfo:
 	awk -vg=0 'g==0{print} /BEGIN codegen h/{g=1; system("./codegen.sh h")} /END codegen h/{g=0; print} g==1{next}' termbox.h >termbox.h.tmp && mv -vf termbox.h.tmp termbox.h
@@ -53,9 +60,23 @@ test_local: $(termbox_so) $(termbox_ffi_h)
 install:
 	$(MAKE) install_h
 
+lib:
+	$(MAKE) $(termbox_h_lib)
+	$(MAKE) $(termbox_a)
+	$(MAKE) $(termbox_so)
+
+install_lib:
+	$(MAKE) install_h_lib
+	$(MAKE) install_a
+	$(MAKE) install_so
+
 install_h: $(termbox_h)
 	install -d $(DESTDIR)$(prefix)/include
 	install -p -m 644 $(termbox_h) $(DESTDIR)$(prefix)/include/$(termbox_h)
+
+install_h_lib: $(termbox_h_lib)
+	install -d $(DESTDIR)$(prefix)/include
+	install -p -m 644 $(termbox_h_lib) $(DESTDIR)$(prefix)/include/$(termbox_h)
 
 install_a: $(termbox_a)
 	install -d $(DESTDIR)$(prefix)/lib
@@ -68,6 +89,6 @@ install_so: $(termbox_so_x_y_z)
 	ln -sf $(termbox_so_x_y_z) $(DESTDIR)$(prefix)/lib/$(termbox_so)
 
 clean:
-	rm -f $(termbox_demos) $(termbox_o) $(termbox_a) $(termbox_so) $(termbox_so_x_y_z) $(termbox_ffi_h) tests/**/observed.ansi
+	rm -f $(termbox_demos) $(termbox_o) $(termbox_a) $(termbox_so) $(termbox_so_x) $(termbox_so_x_y_z) $(termbox_ffi_h) $(termbox_h_lib) tests/**/observed.ansi
 
-.PHONY: all terminfo test test_local install install_h install_a install_so clean
+.PHONY: all lib terminfo test test_local install install_lib install_h install_h_lib install_a install_so clean

--- a/demo/keyboard.c
+++ b/demo/keyboard.c
@@ -2,7 +2,6 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include <stdio.h>
-#define TB_IMPL
 #include "../termbox.h"
 
 struct key {

--- a/termbox.h
+++ b/termbox.h
@@ -56,6 +56,18 @@ SOFTWARE.
 extern "C" {
 #endif
 
+// __ffi_start
+
+#if defined(TB_LIB_OPTS) || 0 // __tb_lib_opts
+// Ensure consistent compile-time options when using as a library
+#undef TB_OPT_TRUECOLOR
+#undef TB_OPT_EGC
+#undef TB_OPT_PRINTF_BUF
+#undef TB_OPT_READ_BUF
+#define TB_OPT_TRUECOLOR
+#define TB_OPT_EGC
+#endif
+
 /* ASCII key constants (tb_event.key) */
 #define TB_KEY_CTRL_TILDE       0x00
 #define TB_KEY_CTRL_2           0x00 /* clash with 'CTRL_TILDE'     */
@@ -297,8 +309,6 @@ extern "C" {
 #define tb_realloc realloc
 #define tb_free    free
 #endif
-
-// __ffi_start
 
 #ifdef TB_OPT_TRUECOLOR
 typedef uint32_t uintattr_t;


### PR DESCRIPTION
This PR installs everything as `termbox.{h,so,a}` with soname version starting at 2. Any opinions on installing as `termbox2.{h,so,a}` instead to avoid conflict with termbox classic? (Tagging @jirutka.)