### PR TITLE
Linterhelp

### DIFF
--- a/termbox.h
+++ b/termbox.h
@@ -1669,6 +1669,8 @@ int tb_set_output_mode(int mode) {
 #endif
             global.output_mode = mode;
             return TB_OK;
+        default:
+            break;
     }
     return TB_ERR;
 }
@@ -1768,6 +1770,8 @@ int tb_set_func(int fn_type, int (*fn)(struct tb_event *, size_t *)) {
         case TB_FUNC_EXTRACT_POST:
             global.fn_extract_esc_post = fn;
             return TB_OK;
+        default:
+            break;
     }
     return TB_ERR;
 }
@@ -2791,6 +2795,8 @@ static int extract_esc_mouse(struct tb_event *event) {
             }
         } break;
         case TYPE_MAX:
+        default:
+            // fallthrough
             ret = TB_ERR;
     }
 


### PR DESCRIPTION
Added default cases to switch statements which did not have them, the default case in each ends with returning TB_FAIL.

Checked and cast narrowing conversions where safe to do so, in one function it made sense to change int16_t to uint16_t, the internal casts of those are non narrowing from an unsigned int.

Added const modifier to uint32_t* ch in send_cluster(), the function dereferences ch and offsets, but never modifies the value. Maybe this helps the compiler in some way? 