### PR TITLE
delete unnecessary if_not_init_return() check in tb_set_cell()

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -1695,7 +1695,6 @@ int tb_hide_cursor(void) {
 }
 
 int tb_set_cell(int x, int y, uint32_t ch, uintattr_t fg, uintattr_t bg) {
-    if_not_init_return();
     return tb_set_cell_ex(x, y, &ch, 1, fg, bg);
 }
 


### PR DESCRIPTION
This PR just deletes a `if_not_init_return()` call that is repeated one line later (after entering `tb_set_cell_ex()`)