### PR TITLE
remove usage of __ prefix for include guard

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -23,8 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#ifndef __TERMBOX_H
-#define __TERMBOX_H
+#ifndef TERMBOX_H_INCL
+#define TERMBOX_H_INCL
 
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
@@ -693,7 +693,7 @@ const char *tb_version(void);
 }
 #endif
 
-#endif /* __TERMBOX_H */
+#endif /* TERMBOX_H_INCL */
 
 #ifdef TB_IMPL
 


### PR DESCRIPTION
`__(something)` is reserved for the C standard, implementation or compiler.

according to the [C99](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf)/[C11](https://www.open-std.org/jtc1/sc22/WG14/www/docs/n1570.pdf) standards, 7.1.3 Reserved identifiers,

> All identifiers that begin with an underscore and either an uppercase letter or another
underscore are always reserved for any use.