### PR TITLE
Added pkg-config file for easier use with build systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ install_lib:
 	$(MAKE) install_h_lib
 	$(MAKE) install_a
 	$(MAKE) install_so
+	cp termbox2.pc /usr/share/pkgconfig
 
 install_h: $(termbox_h)
 	install -d $(DESTDIR)$(prefix)/include

--- a/termbox2.pc
+++ b/termbox2.pc
@@ -1,0 +1,10 @@
+prefix=/usr/local
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: termbox2
+Version: 2.0.0
+Description: Suckless terminal rendering library
+URL: https://github.com/termbox/termbox2
+Cflags: -I${includedir}/
+Libs: -L${libdir} -ltermbox2


### PR DESCRIPTION
This lets you eg. use termbox2 as a `dependency('termbox2')` in meson.