### PR TITLE
Mention Node.js wrapper on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Other wrapper libraries:
 * [Termbox.pm (Perl)](https://github.com/sanko/Termbox.pm)
 * [termbox2-hs (Haskell)](https://github.com/gatlin/termbox2-hs)
 * [termbox2-zig (Zig)](https://sr.ht/~kolunmi/termbox2-zig)
+* [termbox2-node (JavaScript)](https://github.com/RauliL/termbox2-node)
 * [letloop's termbox2 (Chez Scheme)](https://github.com/letloop/letloop/)
 
 ### Examples


### PR DESCRIPTION
I recently created termbox2 (termbox1 already exists but is unmaintained) wrapper library for Node.js JavaScript engine and thought it would be nice to mention about it in README.md in case anyone else than me needs one.