### PR TITLE
cell_reserve_ech: cast realloc return value to uint_32*

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -3340,7 +3340,7 @@ static int cell_reserve_ech(struct tb_cell *cell, size_t n) {
     if (cell->cech >= n) {
         return TB_OK;
     }
-    if (!(cell->ech = tb_realloc(cell->ech, n * sizeof(cell->ch)))) {
+    if (!(cell->ech = (uint32_t*)tb_realloc(cell->ech, n * sizeof(cell->ch)))) {
         return TB_ERR_MEM;
     }
     cell->cech = n;


### PR DESCRIPTION
C++ requires to cast void* on assignment.