### PR TITLE
Fix Unicode character support

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -1574,6 +1574,7 @@ static int bytebuf_reserve(struct bytebuf_t *b, size_t sz);
 static int bytebuf_free(struct bytebuf_t *b);
 
 int tb_init(void) {
+    setlocale(LC_CTYPE, "C.UTF-8"); // Required for iswprint(3) to work properly
     return tb_init_file("/dev/tty");
 }
 

--- a/termbox2.h
+++ b/termbox2.h
@@ -52,6 +52,7 @@ SOFTWARE.
 #include <unistd.h>
 #include <wchar.h>
 #include <wctype.h>
+#include <locale.h>
 
 #ifdef PATH_MAX
 #define TB_PATH_MAX PATH_MAX


### PR DESCRIPTION
Hello! When updating my project to use the latest termbox2 code, I noticed printing characters such as U+250C (and other box drawing characters) stopped working, and instead it printed U+FFFD. This is due to recent changes that makes use of the `iswprint(3)` function to check if a Unicode character is printable or not.
However, by default, C uses the `LC_CTYPE=C` locale, which is ASCII-only, resulting in the aforementioned behavior. To fix this, I've added a line in `tb_init()` that sets `LC_CTYPE` to `C.UTF-8`, which is the same locale but compatible with UTF-8. This should work fine in most systems.