### PR TITLE
Add Newsraft to examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Other wrapper libraries:
 ### Examples
 
 * [mle](https://github.com/adsr/mle) - flexible terminal-based text editor
+* [newsraft](https://codeberg.org/newsraft/newsraft) - feed reader for terminal
 * [ictree](https://github.com/NikitaIvanovV/ictree) - like tree but interactive
 * [lavat](https://github.com/AngelJumbo/lavat) - lava lamp for the terminal
 * [termbox-tetris](https://github.com/zacharygraber/termbox-tetris) - Tetris clone


### PR DESCRIPTION
Hello, @adsr!

I'm the developer of [Newsraft](https://codeberg.org/newsraft/newsraft) and I'm happy to inform you that I successfully revamped the project's user interface code to use [termbox2](https://github.com/termbox/termbox2) library. This rework has proven itself effective with the successful release of [Newsraft 0.31](https://codeberg.org/newsraft/newsraft/releases/tag/newsraft-0.31) and works flawlessly on various flavors of Linux, BSD and macOS.

Originally Newsraft used [NCURSES](https://invisible-island.net/ncurses) and for years there were no issues but one day I received a [report](https://codeberg.org/newsraft/newsraft/issues/187) which revealed a strange problem. In short, `get_wch()` family of functions take keyboard input completely out of service on a very very rare occasion when some shell command is run while a lot of keys are being pressed. I was looking for bug on the Newsraft's side for a couple of days straight and couldn't find anything leading to this behavior at all. Literally all our calls to NCURSES library were protected with mutex locks and the bug still reproduced rarely. I started to look into how NCURSES works under the hood and boy oh boy what I saw in there - I'd describe it as 50K of SLOC(onfusion). I understand that it's not necessary authors' fault that code of NCURSES is so bloated - after all, they have to deal with a lot of curses spec requirements and bear a heavy burden of legacy. Anyway, it was beyond my power to find clues in there either.

So I decided to try out termbox2 as I had a pretty good impression of what it's like from my perspective. The API is pure gold with no unnecessary abstractions like windows, pads, color pairs and other curses crap. Also its source code reads nice and I could understand how it works under the hood in one short sitting. The code is small and well-written. I adapted termbox2 API to curses-like behavior of Newsraft and it worked out all right. The annoying bug was gone even though essentially nothing changed in how the user interface is handled.

I don't rule out the possibility that something was done badly in terms of how NCURSES functions were called in Newsraft but I thought that the time I spent researching this problem was too long to continue. I couldn't find anything more detailed about the bug besides brief description of what happens to report it properly. In any circumstance, the complexity of UI code in Newsraft decreased significantly after termbox2 introduction and I don't have plans to return to NCURSES even if a fix for this bug is ever found. In context of Newsraft in particular I feel like abstractions imposed on us by NCURSES seem overly complex to say the least. As some smart programmers of our time would say, ["never add a dependency you wouldn't feel comfortable debugging"](https://drewdevault.com/2017/09/08/Complicated.html). If the need ever arises again, I'd rather have my hands on termbox2 than come any closer to NCURSES codebase, to be honest.

I added Newsraft to the list of example projects as second, in the order of presence in package repositories. `mle` is most featured but `newsraft` comes second based on Repology data as per June 2025:

* `mle` - [![Packaging status](https://repology.org/badge/tiny-repos/mle.svg)](https://repology.org/project/mle/versions)
* `newsraft` - [![Packaging status](https://repology.org/badge/tiny-repos/newsraft.svg)](https://repology.org/project/newsraft/versions)
* `ictree` - [![Packaging status](https://repology.org/badge/tiny-repos/ictree.svg)](https://repology.org/project/ictree/versions)
* `lavat` - [![Packaging status](https://repology.org/badge/tiny-repos/lavat.svg)](https://repology.org/project/lavat/versions)
* ...

Thanks for maintaining termbox2.

Best regards, Grigory