### PR TITLE
Fix term description lookup according to ncurses behavior

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -3192,9 +3192,9 @@ static int load_terminfo(void) {
     const char *term = getenv("TERM");
     if (!term) return TB_ERR;
 
-    // If TERMINFO is set, try that directory and stop
+    // If TERMINFO is set, try that directory first
     const char *terminfo = getenv("TERMINFO");
-    if (terminfo) return load_terminfo_from_path(terminfo, term);
+    if (terminfo) if_ok_return(rv, load_terminfo_from_path(terminfo, term));
 
     // Next try ~/.terminfo
     const char *home = getenv("HOME");


### PR DESCRIPTION
Hello @adsr

This is the first bugfix from me :)

So currently termbox2 and NCURSES slightly differ in behavior when handling `TERMINFO` environment variable during TERM description lookup.

If you look into these functions in NCURSES:
```
initscr -> newterm -> TINFO_SETUP_TERM -> _nc_setup_tinfo -> _nc_read_entry2
```
you'll find out that NCURSES searches for TERM description in all places possible regardless of whether `TERMINFO` environment variable is forcefully set by the user or not:
```c
_nc_first_db(&state, &offset);
code = TGETENT_ERR;
while ((path = _nc_next_db(&state, &offset)) != 0) {
	code = _nc_read_tic_entry(filename, PATH_MAX, path, name, tp);
	if (code == TGETENT_YES) {
		_nc_last_db();
		break;
	}
}
```

Recently a very attentive user @vaygr found this difference in behavior and reported a bug in Newsraft's issue tracker: https://codeberg.org/newsraft/newsraft/issues/212 You can look into it if you're interested, but tldr is that the patch I propose here fixed the problem and now everything works as before termbox2 was introduced in Newsraft.

Best regards, Grigory