### PR TITLE
set `global.ttyfd` if either `rfd` or `wfd` `isatty`

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -2354,7 +2354,7 @@ int tb_init_rwfd(int rfd, int wfd) {
     int rv;
 
     tb_reset();
-    global.ttyfd = rfd == wfd && isatty(rfd) ? rfd : -1;
+    global.ttyfd = isatty(rfd) ? rfd : (isatty(wfd) ? wfd : -1);
     global.rfd = rfd;
     global.wfd = wfd;
 


### PR DESCRIPTION
Normally, termbox initializes itself by opening `/dev/tty`, but one can also initialize it with arbitrary read and write fds via `tb_init_rwfd`. While this is mainly useful for testing (e.g., `tests/test_mouse`), it may have real world applications as well.

For example, one might want to read input from a pipe and render to a tty. Presently that isn't possible as `tb_init_rwfd` only sets `global.ttyfd` if `rfd == wfd && isatty(rfd)`. Presence of `global.ttyfd` gates execution of various `ioctl`s, like putting the terminal in raw mode, which only makes sense to call if we know the fd is a tty.

In our hypothetical case, the read and write fds are different, and only the write fd is a tty, which we still want to `ioctl`. This patch makes it possible to do this.

The only odd case is if `rfd` and `wfd` are different fds and both ttys. In that case, `rfd` takes precedence (arbitrarily). termbox does not support initializing multiple ttys. (Please do get in touch if you're looking to do that because it sounds cool.)