### PR TITLE
Add more underlines

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -243,11 +243,14 @@ extern "C" {
 /* END codegen h */
 
 /* Some hard-coded caps */
-#define TB_HARDCAP_ENTER_MOUSE  "\x1b[?1000h\x1b[?1002h\x1b[?1015h\x1b[?1006h"
-#define TB_HARDCAP_EXIT_MOUSE   "\x1b[?1006l\x1b[?1015l\x1b[?1002l\x1b[?1000l"
-#define TB_HARDCAP_STRIKEOUT    "\x1b[9m"
-#define TB_HARDCAP_UNDERLINE_2  "\x1b[21m"
-#define TB_HARDCAP_OVERLINE     "\x1b[53m"
+#define TB_HARDCAP_ENTER_MOUSE      "\x1b[?1000h\x1b[?1002h\x1b[?1015h\x1b[?1006h"
+#define TB_HARDCAP_EXIT_MOUSE       "\x1b[?1006l\x1b[?1015l\x1b[?1002l\x1b[?1000l"
+#define TB_HARDCAP_STRIKEOUT        "\x1b[9m"
+#define TB_HARDCAP_UNDERLINE_2      "\x1b[21m"
+#define TB_HARDCAP_OVERLINE         "\x1b[53m"
+#define TB_HARDCAP_UNDERLINE_CURLY  "\x1b[4:3m"
+#define TB_HARDCAP_UNDERLINE_DOTTED "\x1b[4:4m"
+#define TB_HARDCAP_UNDERLINE_DASHED "\x1b[4:5m"
 
 /* Colors (numeric) and attributes (bitwise) (`tb_cell.fg`, `tb_cell.bg`) */
 #define TB_DEFAULT              0x0000
@@ -289,10 +292,14 @@ extern "C" {
 #endif
 
 #if TB_OPT_ATTR_W == 64
-#define TB_STRIKEOUT   0x0000000100000000
-#define TB_UNDERLINE_2 0x0000000200000000
-#define TB_OVERLINE    0x0000000400000000
-#define TB_INVISIBLE   0x0000000800000000
+#define TB_STRIKEOUT        0x0000000100000000
+#define TB_UNDERLINE_2      0x0000000200000000
+#define TB_OVERLINE         0x0000000400000000
+#define TB_INVISIBLE        0x0000000800000000
+#define TB_UNDERLINE_DOUBLY TB_UNDERLINE_2
+#define TB_UNDERLINE_CURLY  0x0000001000000000
+#define TB_UNDERLINE_DOTTED 0x0000002000000000
+#define TB_UNDERLINE_DASHED 0x0000004000000000
 #endif
 
 /* Event types (`tb_event.type`) */
@@ -572,7 +579,8 @@ int tb_set_input_mode(int mode);
  *
  *    The following style attributes are also available if compiled with
  *    `TB_OPT_ATTR_W` set to 64:
- *      `TB_STRIKEOUT`, `TB_UNDERLINE_2`, `TB_OVERLINE`, `TB_INVISIBLE`
+ *      `TB_STRIKEOUT`, `TB_UNDERLINE_2`, `TB_OVERLINE`, `TB_INVISIBLE`,
+ *      `TB_UNDERLINE_CURLY`, `TB_UNDERLINE_DOTTED`, `TB_UNDERLINE_DASHED`
  *
  *    As in all modes, the value 0 is interpreted as `TB_DEFAULT` for
  *    convenience.
@@ -3860,6 +3868,15 @@ static int send_attr(uintattr_t fg, uintattr_t bg) {
     if (fg & TB_INVISIBLE)
         if_err_return(rv,
             bytebuf_puts(&global.out, global.caps[TB_CAP_INVISIBLE]));
+
+    if (fg & TB_UNDERLINE_CURLY)
+        if_err_return(rv, bytebuf_puts(&global.out, TB_HARDCAP_UNDERLINE_CURLY));
+
+    if (fg & TB_UNDERLINE_DOTTED)
+        if_err_return(rv, bytebuf_puts(&global.out, TB_HARDCAP_UNDERLINE_DOTTED));
+
+    if (fg & TB_UNDERLINE_DASHED)
+        if_err_return(rv, bytebuf_puts(&global.out, TB_HARDCAP_UNDERLINE_DASHED));
 #endif
 
     if ((fg & TB_REVERSE) || (bg & TB_REVERSE))

--- a/tests/test_64bit/test.php
+++ b/tests/test_64bit/test.php
@@ -10,9 +10,12 @@ $test->ffi->tb_init();
 
 $attrs = [
     'TB_STRIKEOUT',
-    // 'TB_OVERLINE', // Not supported by xterm
+    // 'TB_OVERLINE',         // Not supported by xterm
     'TB_INVISIBLE',
     'TB_UNDERLINE_2',
+    // 'TB_UNDERLINE_CURLY',  // Not supported by xterm
+    // 'TB_UNDERLINE_DOTTED', // Not supported by xterm
+    // 'TB_UNDERLINE_DASHED'  // Not supported by xterm
 ];
 
 $y = 0;


### PR DESCRIPTION
Many modern terminal emulators support them.   
For example, WezTerm.
The small test:
```c
#define TB_IMPL
#define TB_OPT_ATTR_W 64
#include "termbox2.h"

int main(int argc, char **argv) {
    struct tb_event ev;
    int x = 0;
    int y = 0;

    tb_init();

    tb_printf(x,   y++, TB_GREEN, 0, "green hello from termbox");
    tb_printf(x,   y++, 0, 0, "width=%d height=%d", tb_width(), tb_height());

    tb_printf(x++, y++, TB_BLUE, 0, "Test styles:");

    tb_printf(x,   y++, TB_BOLD, 0,             "TB_BOLD");
    tb_printf(x,   y++, TB_UNDERLINE, 0,        "TB_UNDERLINE");
    tb_printf(x,   y++, TB_REVERSE, 0,          "TB_REVERSE");
    tb_printf(x,   y++, TB_ITALIC, 0,           "TB_ITALIC");
    tb_printf(x,   y++, TB_BLINK, 0,            "TB_BLINK");
    tb_printf(x,   y++, TB_HI_BLACK, 0,         "TB_HI_BLACK");
    tb_printf(x,   y++, TB_BRIGHT, 0,           "TB_BRIGHT");
    tb_printf(x,   y++, TB_DIM, 0,              "TB_DIM");
    tb_printf(x,   y++, TB_STRIKEOUT, 0,        "TB_STRIKEOUT");
    tb_printf(x,   y++, TB_UNDERLINE_2, 0,      "TB_UNDERLINE_2");
    tb_printf(x,   y++, TB_OVERLINE, 0,         "TB_OVERLINE");
    tb_printf(x,   y++, TB_INVISIBLE, 0,        "TB_INVISIBLE");

    tb_printf(x,   y++, TB_DOUBLY_UNDERLINE, 0, "TB_DOUBLY_UNDERLINE");
    tb_printf(x,   y++, TB_CURLY_UNDERLINE, 0,  "TB_CURLY_UNDERLINE");
    tb_printf(x,   y++, TB_DOTTED_UNDERLINE, 0, "TB_DOTTED_UNDERLINE");
    tb_printf(x,   y++, TB_DASHED_UNDERLINE, 0, "TB_DASHED_UNDERLINE");

    tb_printf(0,   y++, 0, 0, "press any key...");

    tb_present();

    tb_poll_event(&ev);

    tb_shutdown();

    return 0;
}
```
<img width="500" height="740" alt="Screenshot_20251021_101258" src="https://github.com/user-attachments/assets/37f084ce-7afb-433a-b949-b64962fd2660" />

