### PR TITLE
Add region mode (for inline TUIs) (attempt 2)

### DIFF
--- a/codegen.sh
+++ b/codegen.sh
@@ -52,6 +52,7 @@ read -r -d '' terminfo_funcs <<'EOD'
     rmkx  EXIT_KEYPAD
     dim   DIM
     invis INVISIBLE
+    ed    CLEAR_EOS
 EOD
 
 read -r -d '' extra_keys <<'EOD'

--- a/demo/keyboard.c
+++ b/demo/keyboard.c
@@ -699,7 +699,11 @@ int main(int argc, char **argv)
 
     setlocale(LC_ALL, "");
 
-    ret = tb_init();
+    if (argc >= 2 && atoi(argv[1]) > 0) {
+        ret = tb_init_ex(1, TB_INIT_REGION, 24);
+    } else {
+        ret = tb_init();
+    }
     if (ret) {
         fprintf(stderr, "tb_init() failed with error code %d\n", ret);
         return 1;

--- a/demo/region.c
+++ b/demo/region.c
@@ -1,0 +1,34 @@
+// cc -DTB_IMPL -I.. region.c -o region
+#include <termbox2.h>
+
+int main(int argc, char **argv) {
+    int sel, y, h, done;
+
+    tb_init_ex(1, TB_INIT_REGION, argc >= 2 ? atoi(argv[1]) : 10);
+
+    done = 0;
+    sel = 0;
+    while (!done) {
+        tb_clear();
+        for (y = 0; y < tb_height(); y++) {
+            tb_printf(0, y, 0, y == sel ? TB_REVERSE : 0, "Item %d", y);
+        }
+        tb_present();
+
+        struct tb_event ev;
+        tb_poll_event(&ev);
+        h = tb_height();
+
+        switch (ev.key) {
+            case TB_KEY_ARROW_UP:   --sel; if (sel <  0) sel = 0;      break;
+            case TB_KEY_ARROW_DOWN: ++sel; if (sel >= h) sel = h - 1;  break;
+            case TB_KEY_ENTER:      done = 1;                          break;
+            case TB_KEY_PGUP:       tb_region(h + 1);                  break;
+            case TB_KEY_PGDN:       tb_region(h - 1);                  break;
+        }
+    }
+    tb_shutdown();
+
+    printf("You picked item %d\n", sel);
+    return 0;
+}

--- a/tests/test_region/expected.ansi
+++ b/tests/test_region/expected.ansi
@@ -1,0 +1,24 @@
+#5[0m14[0m
+#5[0m15[0m
+#5[0m16[0m
+#5[0m17[0m
+#5[0m18[0m
+#5[0m19[0m
+#5[0m20[0m
+#5[0m21[0m
+#5[0m22[0m
+#5[0m23[0m
+#5[0m24[0m
+#5[0muser@host:~ $[0m
+#5[0mline=1 region_h=6 expanded=y shrunk=y[0m
+#5[0mline=2 region_h=6 expanded=y shrunk=y[0m
+#5[0mline=3 region_h=6 expanded=y shrunk=y[0m
+#5[0mline=4 region_h=6 expanded=y shrunk=y[0m
+#5[0mline=5 region_h=6 expanded=y shrunk=y[0m
+#5[0mline=6 region_h=6 expanded=y shrunk=y[0m
+
+
+
+
+
+

--- a/tests/test_region/test.php
+++ b/tests/test_region/test.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+$term_h = (int)shell_exec('tput lines') ?: 24;
+
+# Write some content before we init
+$content = implode("\n", range(1, $term_h));
+$fake_prompt = 'user@host:~ $';
+file_put_contents('/dev/tty', "{$content}\n{$fake_prompt}\n");
+
+$expanded = false;
+$shrunk = false;
+$fill_region = function() use ($test, &$expanded, &$shrunk) {
+    $test->ffi->tb_clear();
+    $w = $test->ffi->tb_width();
+    $h = $test->ffi->tb_height();
+    $y = 0;
+    while ($y < $h) {
+        $test->ffi->tb_printf(0, $y++, 0, 0,
+            "line=%d region_h=%d expanded=%s shrunk=%s",
+            $y, $h, $expanded ? 'y' : 'n', $shrunk ? 'y' : 'n'
+        );
+    }
+};
+
+$init_h = intdiv($term_h, 3);
+$test->ffi->tb_init_ex(1, $test->defines['TB_INIT_REGION'], $init_h);
+$fill_region();
+$test->ffi->tb_present();
+
+$expanded_h = intdiv($term_h, 2);
+$test->ffi->tb_region($expanded_h);
+$event = $test->ffi->new('struct tb_event');
+$rv = $test->ffi->tb_peek_event(FFI::addr($event), 1000);
+$expanded = $event->type === $test->defines['TB_EVENT_RESIZE']
+    && $event->h === $expanded_h
+    && $event->y === $term_h;
+$fill_region();
+$test->ffi->tb_present();
+
+$shrunk_h = intdiv($term_h, 4);
+$test->ffi->tb_region($shrunk_h);
+$event = $test->ffi->new('struct tb_event');
+$rv = $test->ffi->tb_peek_event(FFI::addr($event), 1000);
+$shrunk = $event->type === $test->defines['TB_EVENT_RESIZE']
+    && $event->h === $shrunk_h
+    && $event->y === $term_h;
+$fill_region();
+$test->ffi->tb_present();
+
+$test->screencap();


### PR DESCRIPTION
Same approach as https://github.com/termbox/termbox2/pull/114 except a new variadic function `tb_init_ex` is introduced which accepts a variable number of initialization options, including region mode. I think this is an improvement as it leaves room for future init options and doesn't require awkwardly calling `tb_region` before init.