### PR TITLE
Allow setting a custom function to compute grapheme cluster width

### DIFF
--- a/termbox2.h
+++ b/termbox2.h
@@ -392,6 +392,13 @@ extern "C" {
 #define tb_free    free
 #endif
 
+/* Define this to swap in a different function for computing cluster width. */
+#ifdef tb_cluster_width
+#define TB_CUSTOM_CLUSTER_WIDTH 1
+#else
+#define tb_cluster_width tb_cluster_width_approx
+#endif
+
 #if TB_OPT_ATTR_W == 64
 typedef uint64_t uintattr_t;
 #elif TB_OPT_ATTR_W == 32
@@ -2334,7 +2341,9 @@ static int bytebuf_flush(struct bytebuf *b, int fd);
 static int bytebuf_reserve(struct bytebuf *b, size_t sz);
 static int bytebuf_free(struct bytebuf *b);
 static int tb_iswprint_ex(uint32_t ch, int *width);
-static int tb_cluster_width(uint32_t *ch, size_t nch);
+#ifndef TB_CUSTOM_CLUSTER_WIDTH
+static int tb_cluster_width_approx(uint32_t *ch, size_t nch);
+#endif
 
 int tb_init(void) {
     return tb_init_file("/dev/tty");
@@ -4251,7 +4260,8 @@ int tb_wcwidth(uint32_t ch) {
     return w;
 }
 
-static int tb_cluster_width(uint32_t *ch, size_t nch) {
+#ifndef TB_CUSTOM_CLUSTER_WIDTH
+static int tb_cluster_width_approx(uint32_t *ch, size_t nch) {
     int wmax = -1;
     int vs15 = 0, vs16 = 0, ri = 0, zwj = 0;
     size_t i = 0;
@@ -4272,6 +4282,7 @@ static int tb_cluster_width(uint32_t *ch, size_t nch) {
     }
     return wmax;
 }
+#endif
 
 static int tb_iswprint_ex(uint32_t ch, int *w) {
 #ifdef TB_OPT_LIBC_WCHAR


### PR DESCRIPTION
Example usage:

```c
#include "grapheme.h"
#define tb_cluster_width grapheme_next_character_break
#include "termbox2.h"
```

I've added `TB_CUSTOM_CLUSTER_WIDTH` macro to supress unused function warning (I have it set up in a project I've tested this change in).